### PR TITLE
[1.x] Fixes message and options html output not escaped

### DIFF
--- a/src/Printers/CliPrinter.php
+++ b/src/Printers/CliPrinter.php
@@ -133,6 +133,8 @@ class CliPrinter implements Printer
             return '<span class="text-gray">No message.</span>';
         }
 
+        $message = htmlspecialchars($message);
+
         return "<span>$message</span>";
     }
 
@@ -204,7 +206,8 @@ class CliPrinter implements Printer
         return collect($options)->merge(
             $messageLogged->context() // @phpstan-ignore-line
         )->reject(fn (mixed $value, string|int $key) => is_int($key) && is_null($value))
-            ->map(fn (mixed $value) => is_string($value) ? e($value) : var_export($value, true))
+            ->map(fn (mixed $value) => is_string($value) ? $value : var_export($value, true))
+            ->map(fn (string $value) => htmlspecialchars($value))
             ->map(fn (string $value, string|int $key) => is_string($key) ? "$key: $value" : $value)
             ->map(fn (string $value) => "<span class=\"font-bold\">$value</span>")
             ->implode(' • ');

--- a/tests/Unit/CliPrinterTest.php
+++ b/tests/Unit/CliPrinterTest.php
@@ -114,13 +114,12 @@ test('responsive output exceptions', function () {
     );
 });
 
-test('escaping html options', function () {
+test('escaping message', function () {
     $output = output([
-        'message' => 'Context that contains html',
+        'message' => '<div class=3D"gmail-adL" style=3D"box-sizing:border-box">escaping message</div>',
         'level_name' => 'info',
         'datetime' => '2021-01-01 00:00:00',
         'context' => [
-            'html' => '<div class=3D"gmail-adL" style=3D"box-sizing:border-box"></div>',
             '__pail' => [
                 'origin' => [
                     'type' => 'http',
@@ -131,12 +130,80 @@ test('escaping html options', function () {
                 ],
             ],
         ],
-    ]);
+    ], true);
 
     expect($output)->toBe(<<<'EOF'
-    ┌ 03:04:05 INFO ─────────────────────────────────┐
-    │ Context that contains html                     │
-    └ GET: /logs • Auth ID: guest • html: <div class=3D"gmail-adL" style=3D"box-sizing:border-box"></div> ┘
+    ┌ 2024-01-01 03:04:05 INFO ───────────────────────
+    │ <div class=3D"gmail-adL" style=3D"box-sizing:border-box">escaping message</div>
+    │ 1. app/MyClass.php:12
+    │ 2. app/MyClass.php:34
+    └──────────────────── GET: /logs • Auth ID: guest
+
+    EOF
+    );
+});
+
+test('escaping html options', function () {
+    $output = output([
+        'message' => 'Context that contains html',
+        'level_name' => 'info',
+        'datetime' => '2021-01-01 00:00:00',
+        'context' => [
+            'html' => '<div class=3D"gmail-adL" style=3D"box-sizing:border-box">escaping html options</div>',
+            '__pail' => [
+                'origin' => [
+                    'type' => 'http',
+                    'method' => 'GET',
+                    'path' => '/logs',
+                    'auth_id' => null,
+                    'auth_email' => null,
+                ],
+            ],
+        ],
+    ], true);
+
+    expect($output)->toBe(<<<'EOF'
+    ┌ 2024-01-01 03:04:05 INFO ───────────────────────
+    │ Context that contains html
+    │ 1. app/MyClass.php:12
+    │ 2. app/MyClass.php:34
+    └ GET: /logs • Auth ID: guest • html: <div class=3D"gmail-adL" style=3D"box-sizing:border-box">escaping html options</div>
+
+    EOF
+    );
+});
+
+test('escaping html arrayable options', function () {
+    $output = output([
+        'message' => 'Context that contains html',
+        'level_name' => 'info',
+        'datetime' => '2021-01-01 00:00:00',
+        'context' => [
+            'html' => [
+                'first' => '<span class=3D"gmail-adL">first</span>',
+                'second' => [
+                    'a' => '<span class=3D"gmail-adL">a</span>',
+                    'b' => '<span class=3D"gmail-adL">b</span>',
+                ]
+            ],
+            '__pail' => [
+                'origin' => [
+                    'type' => 'http',
+                    'method' => 'GET',
+                    'path' => '/logs',
+                    'auth_id' => null,
+                    'auth_email' => null,
+                ],
+            ],
+        ],
+    ], true);
+
+    expect($output)->toBe(<<<'EOF'
+    ┌ 2024-01-01 03:04:05 INFO ───────────────────────
+    │ Context that contains html
+    │ 1. app/MyClass.php:12
+    │ 2. app/MyClass.php:34
+    └ GET: /logs • Auth ID: guest • html: array ( 'first' => '<span class=3D"gmail-adL">first</span>', 'second' => array ( 'a' => '<span class=3D"gmail-adL">a</span>', 'b' => '<span class=3D"gmail-adL">b</span>', ), )
 
     EOF
     );

--- a/tests/Unit/CliPrinterTest.php
+++ b/tests/Unit/CliPrinterTest.php
@@ -184,7 +184,7 @@ test('escaping html arrayable options', function () {
                 'second' => [
                     'a' => '<span class=3D"gmail-adL">a</span>',
                     'b' => '<span class=3D"gmail-adL">b</span>',
-                ]
+                ],
             ],
             '__pail' => [
                 'origin' => [


### PR DESCRIPTION
This pull request fixes any message or options not escaped before print them on the console.

Replaces https://github.com/laravel/pail/pull/14.