### PR TITLE
[1.x] Fixes exception as string

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -100,10 +100,10 @@ class Handler
         }
 
         $context['__pail']['origin']['trace'] = isset($messageLogged->context['exception'])
-            && $messageLogged->context['exception'] instanceof Throwable ? collect($messageLogged->context['exception']->getTrace()) // @phpstan-ignore-line
-                ->filter(fn (array $frame) => isset($frame['file'])) // @phpstan-ignore-line
-                ->map(fn (array $frame) => [ // @phpstan-ignore-line
-                    'file' => $frame['file'],
+            && $messageLogged->context['exception'] instanceof Throwable ? collect($messageLogged->context['exception']->getTrace())
+                ->filter(fn (array $frame) => isset($frame['file']))
+                ->map(fn (array $frame) => [
+                    'file' => $frame['file'], // @phpstan-ignore-line
                     'line' => $frame['line'] ?? null,
                 ])->values()
             : null;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -8,6 +8,7 @@ use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Support\Facades\Auth;
+use Throwable;
 
 class Handler
 {
@@ -99,7 +100,7 @@ class Handler
         }
 
         $context['__pail']['origin']['trace'] = isset($messageLogged->context['exception'])
-            ? collect($messageLogged->context['exception']->getTrace()) // @phpstan-ignore-line
+            && $messageLogged->context['exception'] instanceof Throwable ? collect($messageLogged->context['exception']->getTrace()) // @phpstan-ignore-line
                 ->filter(fn (array $frame) => isset($frame['file'])) // @phpstan-ignore-line
                 ->map(fn (array $frame) => [ // @phpstan-ignore-line
                     'file' => $frame['file'],

--- a/tests/Features/CommandTest.php
+++ b/tests/Features/CommandTest.php
@@ -174,3 +174,22 @@ test('multiple exceptions and messages and verbose', function () {
 
         EOF, verbose: true);
 });
+
+test('exception key as string', function () {
+    expect([
+        'Log::error("log message", ["exception" => "an exception occured"])',
+        'throw new Exception("my exception message")',
+    ])->toPail(<<<'EOF'
+        ┌ 2024-01-01 03:04:05 ERROR ──────────────────────
+        │ log message
+        │ 1. app/MyClass.php:12
+        │ 2. app/MyClass.php:34
+        └──────────────────────────────────────── artisan
+        ┌ 2024-01-01 03:04:05 Exception  app/MyClass.php:12
+        │ my exception message
+        │ 1. app/MyClass.php:12
+        │ 2. app/MyClass.php:34
+        └──────────────────────────────────────── artisan
+
+        EOF, verbose: true);
+});


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/pail/issues/21, when the `exception` key is a string instead of a Throwable  instance.