### PR TITLE
Add support for --no-timeout option

### DIFF
--- a/src/Console/Commands/PailCommand.php
+++ b/src/Console/Commands/PailCommand.php
@@ -78,7 +78,7 @@ class PailCommand extends Command
 
         $options = Options::fromCommand($this);
 	    
-	    $noTimeout = $this->option('no-timeout');
+	    $noTimeout = (bool) $this->option('no-timeout');
 
         assert($this->file instanceof File);
 

--- a/src/Console/Commands/PailCommand.php
+++ b/src/Console/Commands/PailCommand.php
@@ -23,7 +23,8 @@ class PailCommand extends Command
         {--message= : Filter the logs by the message}
         {--level= : Filter the logs by the level}
         {--auth= : Filter the logs by the authenticated ID}
-        {--user= : Filter the logs by the authenticated ID (alias for --auth)}';
+        {--user= : Filter the logs by the authenticated ID (alias for --auth)}
+        {--no-timeout : Disable timeout of command. Default 1 hour }';
 
     /**
      * {@inheritDoc}
@@ -76,11 +77,13 @@ class PailCommand extends Command
         $this->trap([SIGINT, SIGTERM], fn () => $this->file->destroy());
 
         $options = Options::fromCommand($this);
+	    
+	    $noTimeout = $this->option('no-timeout');
 
         assert($this->file instanceof File);
 
         try {
-            $processFactory->run($this->file, $this->output, $this->laravel->basePath(), $options);
+            $processFactory->run($this->file, $this->output, $this->laravel->basePath(), $options, $noTimeout);
         } catch (ProcessSignaledException $e) {
             if (in_array($e->getSignal(), [SIGINT, SIGTERM], true)) {
                 $this->newLine();

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -13,13 +13,13 @@ class ProcessFactory
     /**
      * Creates a new instance of the process factory.
      */
-    public function run(File $file, OutputInterface $output, string $basePath, Options $options): void
+	public function run(File $file, OutputInterface $output, string $basePath, Options $options, bool $noTimeout): void
     {
         $printer = new CliPrinter($output, $basePath);
 
         $remainingBuffer = '';
-
-        Process::timeout(3600)
+	    
+	    Process::timeout($noTimeout ? PHP_INT_MAX : 3600)
             ->tty(false)
             ->run(
                 $this->command($file),


### PR DESCRIPTION
This PR adds support for optional parameter **--no-timeout** when you start pail. 

This feature is good for longer monitoring sessions.

Current:

`php artisan pail`

pail command exits default after 3600 seconds (1 hour).

With the new feature:

`php artisan pail --no-timeout`

pail command will run forever. 