### PR TITLE
Remove timeout

### DIFF
--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -19,7 +19,7 @@ class ProcessFactory
 
         $remainingBuffer = '';
 
-        Process::timeout(3600)
+        Process::forever()
             ->tty(false)
             ->run(
                 $this->command($file),


### PR DESCRIPTION
Currently `artisan pail` runs the `tail -f` process with a timeout of 3600 (1 hour).
I would argue that this timeout is arbitrary, unnecessary and counter intuitive:
- If you run `tail -f` manually in the terminal, it won't have a timeout.
- When you run a php script in cli, it won't have a timeout by default.
- Tailing a log file for several hours is not an uncommon practice. See #26 and #27.

This PR simply allows the `artisan pail` command to run until the user stops it.

