### PR TITLE
[1.x] Adds `--timeout` option

### DIFF
--- a/src/Console/Commands/PailCommand.php
+++ b/src/Console/Commands/PailCommand.php
@@ -25,7 +25,8 @@ class PailCommand extends Command
         {--message= : Filter the logs by the given message}
         {--level= : Filter the logs by the given level}
         {--auth= : Filter the logs by the given authenticated ID}
-        {--user= : Filter the logs by the given authenticated ID (alias for --auth)}';
+        {--user= : Filter the logs by the given authenticated ID (alias for --auth)}
+        {--timeout=3600 : The maximum execution time in seconds}';
 
     /**
      * {@inheritDoc}

--- a/src/Options.php
+++ b/src/Options.php
@@ -11,6 +11,7 @@ class Options
      * Creates a new instance of the tail options.
      */
     public function __construct(
+        protected ?int $timeout,
         protected ?string $authId,
         protected ?string $level,
         protected ?string $filter,
@@ -36,7 +37,9 @@ class Options
         $message = $command->option('message');
         assert(is_string($message) || $message === null);
 
-        return new static($authId, $level, $filter, $message);
+        $timeout = (int) $command->option('timeout');
+
+        return new static($timeout, $authId, $level, $filter, $message);
     }
 
     /**
@@ -61,5 +64,13 @@ class Options
         }
 
         return true;
+    }
+
+    /**
+     * Returns the number of seconds before the process is killed or null if no timeout is set.
+     */
+    public function timeout(): ?int
+    {
+        return $this->timeout === 0 ? null : $this->timeout;
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -11,7 +11,7 @@ class Options
      * Creates a new instance of the tail options.
      */
     public function __construct(
-        protected ?int $timeout,
+        protected int $timeout,
         protected ?string $authId,
         protected ?string $level,
         protected ?string $filter,

--- a/src/Options.php
+++ b/src/Options.php
@@ -67,10 +67,10 @@ class Options
     }
 
     /**
-     * Returns the number of seconds before the process is killed or null if no timeout is set.
+     * Returns the number of seconds before the process is killed.
      */
-    public function timeout(): ?int
+    public function timeout(): int
     {
-        return $this->timeout === 0 ? null : $this->timeout;
+        return $this->timeout;
     }
 }

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -19,7 +19,7 @@ class ProcessFactory
 
         $remainingBuffer = '';
 
-        Process::timeout(3600)
+        Process::timeout($options->timeout())
             ->tty(false)
             ->run(
                 $this->command($file),


### PR DESCRIPTION
This pull request adds the `--timeout` option to the `artisan pail` command.

```
// regular timeout, defaults to 3600
artisan pail

// no timeout
artisan pail --timeout=0
```
