### PR TITLE
Support multiline logs

### DIFF
--- a/src/Printers/CliPrinter.php
+++ b/src/Printers/CliPrinter.php
@@ -135,7 +135,7 @@ class CliPrinter implements Printer
 
         $message = htmlspecialchars($message);
 
-        return "<span>$message</span>";
+        return "<pre>$message</pre>";
     }
 
     /**

--- a/src/Printers/CliPrinter.php
+++ b/src/Printers/CliPrinter.php
@@ -135,7 +135,11 @@ class CliPrinter implements Printer
 
         $message = htmlspecialchars($message);
 
-        return "<pre>$message</pre>";
+        if(strstr($message, PHP_EOL)) {
+            return "<pre>$message</pre>";
+        }
+
+        return "<span>$message</span>";
     }
 
     /**

--- a/src/Printers/CliPrinter.php
+++ b/src/Printers/CliPrinter.php
@@ -135,7 +135,7 @@ class CliPrinter implements Printer
 
         $message = htmlspecialchars($message);
 
-        if(strstr($message, PHP_EOL)) {
+        if (strstr($message, PHP_EOL)) {
             return "<pre>$message</pre>";
         }
 


### PR DESCRIPTION
Fix for https://github.com/laravel/pail/issues/53

Note that multiline logs drop pipe "|" at the start of log line. I vote this as a benefit as it allows to easily copy multiline text without selecting pipes

### Code snippet

```php
$test_var = ['user_name' => "John smith", "hobbies" => ['sailing', 'sim racing', 'gardening']];

\Log::warning(json_encode($test_var, JSON_PRETTY_PRINT), [__FILE__ . ' | ' . __FUNCTION__ . ':' . __LINE__]);
\Log::warning(($test_var), [__FILE__ . ' | ' . __FUNCTION__ . ':' . __LINE__]);
\Log::warning('just a single line', [__FILE__ . ' | ' . __FUNCTION__ . ':' . __LINE__]);
```

### Log output before

```pail logs
┌ 2025-04-21 17:22:41 WARNING ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ { "user_name": "John smith", "hobbies": [ "sailing", "sim racing", "gardening" ] }
└──────────────────────────────────────── GET: /venue-editor • Auth ID: 1 (mail@email.com) • /var/www/html/app/Livewire/VenueEditor.php | render:82
┌ 2025-04-21 17:22:41 WARNING ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ array ( 'user_name' => 'John smith', 'hobbies' => array ( 0 => 'sailing', 1 => 'sim racing', 2 => 'gardening', ), )
└──────────────────────────────────────── GET: /venue-editor • Auth ID: 1 (mail@email.com) • /var/www/html/app/Livewire/VenueEditor.php | render:83
┌ 2025-04-21 17:22:41 WARNING ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ just a single line
└──────────────────────────────────────── GET: /venue-editor • Auth ID: 1 (mail@email.com) • /var/www/html/app/Livewire/VenueEditor.php | render:84
```

### Log output after

```pail logs
┌ 2025-04-21 17:43:42 WARNING ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│
{
    "user_name": "John smith",
    "hobbies": [
        "sailing",
        "sim racing",
        "gardening"
    ]
}
└──────────────────────────────────────── GET: /venue-editor • Auth ID: 1 (mail@email.com) • /var/www/html/app/Livewire/VenueEditor.php | render:82
┌ 2025-04-21 17:43:42 WARNING ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│
array (
  'user_name' => 'John smith',
  'hobbies' =>
  array (
    0 => 'sailing',
    1 => 'sim racing',
    2 => 'gardening',
  ),
)
└──────────────────────────────────────── GET: /venue-editor • Auth ID: 1 (mail@email.com) • /var/www/html/app/Livewire/VenueEditor.php | render:83
┌ 2025-04-21 17:43:42 WARNING ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ just a single line
└──────────────────────────────────────── GET: /venue-editor • Auth ID: 1 (mail@email.com) • /var/www/html/app/Livewire/VenueEditor.php | render:84
```