### PR TITLE
Suggests `laravel/pail` as dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "laravel/pail",
     "description": "Easily delve into your Laravel application's log files directly from the command line.",
-    "keywords": ["php", "tail", "laravel", "logs"],
+    "keywords": ["php", "tail", "laravel", "logs", "dev"],
     "homepage": "https://github.com/laravel/pail",
     "license": "MIT",
     "support": {


### PR DESCRIPTION
Currently running `composer require "laravel/pail"` will install under `require` instead of `require-dev`. Adding the keyword will add a confirmation before installation.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
