### PR TITLE
Update command description formatting to match all other Laravel Commands

### DIFF
--- a/src/Console/Commands/PailCommand.php
+++ b/src/Console/Commands/PailCommand.php
@@ -31,7 +31,7 @@ class PailCommand extends Command
     /**
      * {@inheritDoc}
      */
-    protected $description = 'Tails the application logs.';
+    protected $description = 'Tails the application logs';
 
     /**
      * The file instance, if any.


### PR DESCRIPTION
Removed the period from the command description. This is consistent with all other Laravel commands, which do not end in a period.


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
