### PR TITLE
Fix crash when log file contains malformed JSON lines

### DIFF
--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -39,7 +39,8 @@ class ProcessFactory
 
                     $lines
                         ->filter(fn (string $line) => $line !== '')
-                        ->map(fn (string $line) => MessageLogged::fromJson($line))
+                        ->map(fn (string $line) => MessageLogged::tryFromJson($line))
+                        ->filter()
                         ->filter(fn (MessageLogged $messageLogged) => $options->accepts($messageLogged))
                         ->each(fn (MessageLogged $messageLogged) => $printer->print($messageLogged));
                 }

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -39,10 +39,13 @@ class ProcessFactory
 
                     $lines
                         ->filter(fn (string $line) => $line !== '')
-                        ->map(fn (string $line) => MessageLogged::tryFromJson($line))
-                        ->filter()
-                        ->filter(fn (MessageLogged $messageLogged) => $options->accepts($messageLogged))
-                        ->each(fn (MessageLogged $messageLogged) => $printer->print($messageLogged));
+                        ->each(function (string $line) use ($options, $printer) {
+                            $messageLogged = MessageLogged::tryFromJson($line);
+
+                            if ($messageLogged !== null && $options->accepts($messageLogged)) {
+                                $printer->print($messageLogged);
+                            }
+                        });
                 }
             );
     }

--- a/src/ValueObjects/MessageLogged.php
+++ b/src/ValueObjects/MessageLogged.php
@@ -41,6 +41,20 @@ class MessageLogged implements Stringable
     }
 
     /**
+     * Attempt to create a new instance of the message logged from a json string.
+     *
+     * Returns null if the JSON is malformed or missing required fields.
+     */
+    public static function tryFromJson(string $json): ?static
+    {
+        try {
+            return static::fromJson($json);
+        } catch (\JsonException|\ValueError) {
+            return null;
+        }
+    }
+
+    /**
      * Gets the log message's message.
      */
     public function message(): string

--- a/src/ValueObjects/MessageLogged.php
+++ b/src/ValueObjects/MessageLogged.php
@@ -49,7 +49,7 @@ class MessageLogged implements Stringable
     {
         try {
             return static::fromJson($json);
-        } catch (\JsonException|\ValueError) {
+        } catch (\Throwable) {
             return null;
         }
     }

--- a/tests/Unit/MessageLoggedTest.php
+++ b/tests/Unit/MessageLoggedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Laravel\Pail\ValueObjects\MessageLogged;
+
+test('tryFromJson returns null for malformed json', function () {
+    expect(MessageLogged::tryFromJson('not valid json'))->toBeNull();
+});
+
+test('tryFromJson returns null for empty string', function () {
+    expect(MessageLogged::tryFromJson(''))->toBeNull();
+});
+
+test('tryFromJson returns null for truncated json', function () {
+    expect(MessageLogged::tryFromJson('{"message": "hello"'))->toBeNull();
+});
+
+test('tryFromJson returns null for json missing required fields', function () {
+    expect(MessageLogged::tryFromJson('{"foo": "bar"}'))->toBeNull();
+});
+
+test('tryFromJson returns message for valid json', function () {
+    $json = json_encode([
+        'message' => 'Hello World',
+        'level_name' => 'INFO',
+        'datetime' => '2021-01-01T00:00:00.000000+00:00',
+        'context' => [
+            '__pail' => [
+                'origin' => [
+                    'type' => 'console',
+                    'command' => 'inspire',
+                ],
+            ],
+        ],
+    ]);
+
+    $result = MessageLogged::tryFromJson($json);
+
+    expect($result)->toBeInstanceOf(MessageLogged::class)
+        ->and($result->message())->toBe('Hello World')
+        ->and($result->level())->toBe('INFO');
+});


### PR DESCRIPTION
## Summary

Fixes a crash where Pail throws a `JsonException` when encountering malformed JSON in log output, terminating the entire tail session.

Fixes laravel/pail#58

## Problem

Pail reads log files line by line and parses each line as JSON. If any line contains malformed JSON (e.g., truncated output from a crash, non-JSON log entries from other processes, or corrupted writes), `json_decode` throws a `JsonException` and Pail exits:

```
JsonException: Syntax error in vendor/laravel/pail/src/MessageLogged.php
```

This is especially common when PHP itself writes fatal error output directly to the log file. Multiple users are reporting this crash during local development, some experiencing it every ~2 hours, which kills their entire dev server when running Pail via `concurrently` (see #58).

<details>
<summary>Before fix (crashes on first malformed line)</summary>

```
INFO  Tailing application logs.

┌ 11:50:00 INFO ───────────────────────────────────────────────────────────────┐
│ BEFORE the crash                                                             │
└────────────────────────────────────────────────────────────── artisan tinker ┘

   JsonException

  Syntax error

  at vendor/laravel/pail/src/ValueObjects/MessageLogged.php:31
     27▕      */
     28▕     public static function fromJson(string $json): static
     29▕     {
  ➜  31▕         $array = json_decode($json, true, 512, JSON_THROW_ON_ERROR);

  # Stack trace trimmed. Pail exits with code 1. "AFTER" log entry never appears.
```

</details>

<details>
<summary>After fix (skips malformed lines, keeps running)</summary>

```
INFO  Tailing application logs.

┌ 11:49:02 INFO ───────────────────────────────────────────────────────────────┐
│ BEFORE the crash                                                             │
└────────────────────────────────────────────────────────────── artisan tinker ┘
┌ 11:49:11 INFO ───────────────────────────────────────────────────────────────┐
│ AFTER the crash - Pail survived!                                             │
└────────────────────────────────────────────────────────────── artisan tinker ┘

  # 5 malformed lines (PHP fatal, stack trace, broken JSON) silently skipped.
  # Pail continues tailing normally.
```

</details>

## Solution

Add `MessageLogged::tryFromJson()` that returns `null` instead of throwing on invalid input. Update `ProcessFactory` to use `tryFromJson()` and filter out unparseable lines gracefully, keeping the tail session alive.

This follows PHP's established `tryFrom` convention (e.g., `BackedEnum::tryFrom()`, `DateTimeImmutable::createFromFormat()`).

## Note

I intentionally kept the skip silent rather than printing a warning (e.g., `⚠ Pail skipped a malformed log line`) to avoid noisy output during PHP crashes that dump multiple lines. Happy to add a warning if preferred.

## Test Plan

- [x] Unit tests added for `tryFromJson()` covering malformed JSON, empty strings, truncated JSON, and missing required fields
- [x] Unit test confirming valid JSON still parses correctly
- [x] Manual testing: introduce a syntax error in a PHP file while Pail is running to verify it no longer crashes