### PR TITLE
Show deprecation warnings when deprecation logging is configured

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -50,7 +50,8 @@ class Handler
         }
 
         if (
-            $messageLogged->level === LogLevel::WARNING
+            ! config('logging.deprecations.channel')
+            && $messageLogged->level === LogLevel::WARNING
             && Str::contains($messageLogged->message, ['deprecated', 'Deprecated', '[\ReturnTypeWillChange]'])
         ) {
             return;

--- a/tests/Unit/HandlerTest.php
+++ b/tests/Unit/HandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Config;
+use Laravel\Pail\Files;
+use Laravel\Pail\Handler;
+
+beforeEach(function () {
+    $this->pailDir = sys_get_temp_dir().'/pail-test-'.uniqid();
+    mkdir($this->pailDir, 0755, true);
+    touch($this->pailDir.'/test.pail');
+
+    $this->files = new Files($this->pailDir);
+
+    $this->handler = new Handler(
+        $this->app,
+        $this->files,
+        true,
+    );
+});
+
+afterEach(function () {
+    @unlink($this->pailDir.'/test.pail');
+    @rmdir($this->pailDir);
+});
+
+test('filters deprecation warnings when deprecation channel is not configured', function () {
+    Config::set('logging.deprecations.channel', null);
+
+    $this->handler->log(new MessageLogged('warning', 'Function deprecated since v2.0', []));
+
+    $contents = file_get_contents($this->pailDir.'/test.pail');
+
+    expect($contents)->toBeEmpty();
+});
+
+test('shows deprecation warnings when deprecation channel is configured', function () {
+    Config::set('logging.deprecations.channel', 'stack');
+
+    $this->handler->log(new MessageLogged('warning', 'Function deprecated since v2.0', []));
+
+    $contents = file_get_contents($this->pailDir.'/test.pail');
+
+    expect($contents)->toContain('Function deprecated since v2.0');
+});
+
+test('does not filter non-deprecation warning messages', function () {
+    Config::set('logging.deprecations.channel', null);
+
+    $this->handler->log(new MessageLogged('warning', 'Disk space running low', []));
+
+    $contents = file_get_contents($this->pailDir.'/test.pail');
+
+    expect($contents)->toContain('Disk space running low');
+});


### PR DESCRIPTION
## Summary

When a developer has explicitly configured a deprecation log channel via `logging.deprecations.channel`, Pail should display those deprecation warnings in its output. Currently, PR #57 added a hardcoded filter that suppresses all PHP deprecation warnings unconditionally.

Fixes laravel/pail#63

## Problem

PR #57 added filtering that removes all PHP deprecation warnings from Pail output. While this reduces noise by default, it also hides deprecations from developers who have explicitly opted into tracking them by setting `logging.deprecations.channel` in their config.

## Solution

Check `config('logging.deprecations.channel')` before filtering. If the application has configured a deprecation channel, the developer wants to see these warnings, so Pail displays them. If no channel is configured (the default), deprecations remain filtered out.

## Before/After

**Before:** All deprecation warnings are hidden from Pail output, regardless of configuration.

**After:**
- Without `logging.deprecations.channel` set: deprecations are still filtered (default behavior preserved)
- With `logging.deprecations.channel` set: deprecations appear in Pail output

## Test Plan

- Without `logging.deprecations.channel` set: verify deprecation warnings are still filtered
- With `logging.deprecations.channel` set: verify deprecation warnings appear in output
- Non-deprecation log messages always appear regardless of configuration