### PR TITLE
fix: prevent Pail from crashing on malformed JSON log lines

### DIFF
--- a/src/LoggerFactory.php
+++ b/src/LoggerFactory.php
@@ -24,7 +24,7 @@ class LoggerFactory
      */
     public function create(): LoggerInterface
     {
-        $handler = new StreamHandler($this->file->__toString(), Level::Debug);
+        $handler = new StreamHandler($this->file->__toString(), Level::Debug, true, null, true);
         $handler->setFormatter(new JsonFormatter);
 
         return new Logger('pail', [$handler]);

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -39,26 +39,20 @@ class ProcessFactory
 
                     $lines
                         ->filter(fn (string $line) => $line !== '')
-                        ->map(fn (string $line) => $this->parseMessageLogged($line, $output))
+                        ->map(function (string $line) use ($output): ?MessageLogged {
+                            try {
+                                return MessageLogged::fromJson($line);
+                            } catch (\Throwable) {
+                                $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
+
+                                return null;
+                            }
+                        })
                         ->filter()
                         ->filter(fn (MessageLogged $messageLogged) => $options->accepts($messageLogged))
                         ->each(fn (MessageLogged $messageLogged) => $printer->print($messageLogged));
                 }
             );
-    }
-
-    /**
-     * Parse the given log line, ignoring invalid JSON.
-     */
-    protected function parseMessageLogged(string $line, OutputInterface $output): ?MessageLogged
-    {
-        try {
-            return MessageLogged::fromJson($line);
-        } catch (\Throwable) {
-            $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
-
-            return null;
-        }
     }
 
     /**

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -55,9 +55,7 @@ class ProcessFactory
         try {
             return MessageLogged::fromJson($line);
         } catch (\Throwable) {
-            if ($output->isVerbose()) {
-                $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
-            }
+            $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
 
             return null;
         }

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -23,7 +23,7 @@ class ProcessFactory
             ->tty(false)
             ->run(
                 $this->command($file),
-                function (string $type, string $buffer) use ($options, $printer, &$remainingBuffer) {
+                function (string $type, string $buffer) use ($options, $printer, &$remainingBuffer, $output) {
                     $lines = Str::of($buffer)->explode("\n");
 
                     if ($remainingBuffer !== '' && isset($lines[0])) {
@@ -39,11 +39,28 @@ class ProcessFactory
 
                     $lines
                         ->filter(fn (string $line) => $line !== '')
-                        ->map(fn (string $line) => MessageLogged::fromJson($line))
+                        ->map(fn (string $line) => $this->parseMessageLogged($line, $output))
+                        ->filter()
                         ->filter(fn (MessageLogged $messageLogged) => $options->accepts($messageLogged))
                         ->each(fn (MessageLogged $messageLogged) => $printer->print($messageLogged));
                 }
             );
+    }
+
+    /**
+     * Parse the given log line, ignoring invalid JSON.
+     */
+    protected function parseMessageLogged(string $line, OutputInterface $output): ?MessageLogged
+    {
+        try {
+            return MessageLogged::fromJson($line);
+        } catch (\Throwable) {
+            if ($output->isVerbose()) {
+                $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
+            }
+
+            return null;
+        }
     }
 
     /**

--- a/tests/Features/CommandTest.php
+++ b/tests/Features/CommandTest.php
@@ -205,3 +205,17 @@ test('using context facade', function () {
         EOF,
     );
 })->skip(! class_exists(Context::class), 'Context facade is not available in this version of Laravel');
+
+test('malformed logs', function () {
+    expect([
+        'file_put_contents(collect(glob(storage_path("pail/*.pail")))->last(), "invalid json\n", FILE_APPEND)',
+        'app("log")->debug("test debug message")',
+    ])->toPail(<<<'EOF'
+          ⚠ Pail skipped a malformed log line.
+        ┌ 03:04:05 DEBUG ────────────────────────────────┐
+        │ test debug message                             │
+        └────────────────────────────────── artisan eval ┘
+
+        EOF,
+    );
+});


### PR DESCRIPTION
### Issue:
Currently, `Pail` crashes entirely with a `JsonException: Syntax error` if it encounters a malformed JSON line (which happens occasionally during concurrent writes).

### Error Code snippet:
```
[logs]    JsonException 
[logs] 
[logs]   Syntax error
[logs] 
[logs]   at vendor/laravel/pail/src/ValueObjects/MessageLogged.php:31
[logs]      27▕      */
[logs]      28▕     public static function fromJson(string $json): static
[logs]      29▕     {
[logs]      30▕         /** @var array{message: string, context: array{__pail: array{origin: array{trace: array<int, array{file: string, line: int}>|null, type: string, queue: string, job: string, command: string, method: string, path: string, auth_id: ?string, auth_email: ?string}}, exception: array{class: string, file: string}}, level_name: string, datetime: string} $array */
[logs]   ➜  31▕         $array = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
[logs]      32▕ 
[logs]      33▕         [
[logs]      34▕             'message' => $message,
[logs]      35▕             'datetime' => $datetime,
[logs] 
[logs]       +2 vendor frames 
[logs] 
[logs]   3   [internal]:0
[logs]       Laravel\Pail\ProcessFactory::{closure:{closure:Laravel\Pail\ProcessFactory::run():26}:42}()
[logs]       +24 vendor frames 
[logs] 
[logs]   28  artisan:16
[logs]       Illuminate\Foundation\Application::handleCommand()
[logs] 
[logs] php artisan pail --timeout=0 exited with code 1
--> Sending SIGTERM to other processes..
[queue] php artisan queue:listen --tries=1 exited with code SIGTERM
--> Sending SIGTERM to other processes..
[server] php artisan serve exited with code SIGTERM
--> Sending SIGTERM to other processes..
[vite] npm run dev exited with code SIGTERM
Script npx concurrently -c "#93c5fd,#c4b5fd,#fb7185,#fdba74" "php artisan serve" "php artisan queue:listen --tries=1" "php artisan pail --timeout=0" "npm run dev" --names=server,queue,logs,vite --kill-others handling the dev event returned with error code 1
```

### Reproduce:
Terminal A:
```
php artisan pail
```

Terminal B:
```
until f=$(ls -t storage/pail/*.pail 2>/dev/null | head -n1) && [ -n "$f" ]; do sleep 0.1; done
echo "Injecting bad line into: $f"
printf '{"message":\n' >> "$f"
```

### Explanation:
I wrap the `MessageLogged::fromJson` call in a `try/catch`. Instead of killing the entire watcher process, it will now just skip the corrupted line and keep running. I also added a small terminal warning _(⚠ Pail skipped a malformed log line)_ and a test for that.