### PR TITLE
Draft: Add support for tailing custom log files via --file option

### DIFF
--- a/src/Console/Commands/PailCommand.php
+++ b/src/Console/Commands/PailCommand.php
@@ -26,6 +26,7 @@ class PailCommand extends Command
         {--level= : Filter the logs by the given level}
         {--auth= : Filter the logs by the given authenticated ID}
         {--user= : Filter the logs by the given authenticated ID (alias for --auth)}
+        {--file= : The path to a custom log file to tail}
         {--timeout=3600 : The maximum execution time in seconds}';
 
     /**
@@ -47,36 +48,42 @@ class PailCommand extends Command
 
         renderUsing($this->output);
         render(<<<'HTML'
-            <div class="max-w-150 mx-2 mt-1 flex">
-                <div>
-                    <span class="px-1 bg-blue uppercase text-white">INFO</span>
-                    <span class="flex-1">
-                        <span class="ml-1 ">Tailing application logs.</span>
-                    </span>
-                </div>
-                <span class="flex-1"></span>
-                <span class="text-gray ml-1">
-                    <span class="text-gray">Press Ctrl+C to exit</span>
+        <div class="max-w-150 mx-2 mt-1 flex">
+            <div>
+                <span class="px-1 bg-blue uppercase text-white">INFO</span>
+                <span class="flex-1">
+                    <span class="ml-1 ">Tailing application logs.</span>
                 </span>
             </div>
-            HTML,
+            <span class="flex-1"></span>
+            <span class="text-gray ml-1">
+                <span class="text-gray">Press Ctrl+C to exit</span>
+            </span>
+        </div>
+        HTML,
         );
 
         render(<<<'HTML'
-            <div class="max-w-150 mx-2 flex">
-                <div>
-                </div>
-                <span class="flex-1"></span>
-                <span class="text-gray ml-1">
-                    <span class="text-gray">Use -v|-vv to show more details</span>
-                </span>
+        <div class="max-w-150 mx-2 flex">
+            <div>
             </div>
-            HTML,
+            <span class="flex-1"></span>
+            <span class="text-gray ml-1">
+                <span class="text-gray">Use -v|-vv to show more details</span>
+            </span>
+        </div>
+        HTML,
         );
 
-        $this->file = new File(storage_path('pail/'.uniqid().'.pail'));
-        $this->file->create();
-        $this->trap([SIGINT, SIGTERM], fn () => $this->file->destroy());
+        $customFilePath = $this->option('file');
+
+        if (is_string($customFilePath) && $customFilePath !== '') {
+            $this->file = new File($customFilePath);
+        } else {
+            $this->file = new File(storage_path('pail/'.uniqid().'.pail'));
+            $this->file->create();
+            $this->trap([SIGINT, SIGTERM], fn () => $this->file->destroy());
+        }
 
         $options = Options::fromCommand($this);
 
@@ -91,7 +98,9 @@ class PailCommand extends Command
         } catch (ProcessTimedOutException $e) {
             $this->components->info('Maximum execution time exceeded.');
         } finally {
-            $this->file?->destroy();
+            if (! is_string($customFilePath) || $customFilePath === '') {
+                $this->file?->destroy();
+            }
         }
     }
 
@@ -100,7 +109,7 @@ class PailCommand extends Command
      */
     public function __destruct()
     {
-        if ($this->file) {
+        if ($this->file && ! $this->option('file')) {
             $this->file->destroy();
         }
     }

--- a/src/Console/Commands/PailCommand.php
+++ b/src/Console/Commands/PailCommand.php
@@ -98,7 +98,7 @@ class PailCommand extends Command
         } catch (ProcessTimedOutException $e) {
             $this->components->info('Maximum execution time exceeded.');
         } finally {
-            if (! is_string($customFilePath) || $customFilePath === '') {
+            if (! $this->option('file')) {
                 $this->file?->destroy();
             }
         }

--- a/src/Console/Commands/PailCommand.php
+++ b/src/Console/Commands/PailCommand.php
@@ -77,7 +77,7 @@ class PailCommand extends Command
 
         $customFilePath = $this->option('file');
 
-        if (is_string($customFilePath) && $customFilePath !== '') {
+        if (is_string($customFilePath) && !empty($customFilePath)) {
             $this->file = new File($customFilePath);
         } else {
             $this->file = new File(storage_path('pail/'.uniqid().'.pail'));

--- a/src/Options.php
+++ b/src/Options.php
@@ -16,6 +16,7 @@ class Options
         protected ?string $level,
         protected ?string $filter,
         protected ?string $message,
+        protected ?string $file = null,
     ) {
         //
     }
@@ -37,9 +38,12 @@ class Options
         $message = $command->option('message');
         assert(is_string($message) || $message === null);
 
+        $file = $command->option('file');
+        assert(is_string($file) || $file === null);
+
         $timeout = (int) $command->option('timeout');
 
-        return new static($timeout, $authId, $level, $filter, $message);
+        return new static($timeout, $authId, $level, $filter, $message, $file);
     }
 
     /**
@@ -72,5 +76,13 @@ class Options
     public function timeout(): int
     {
         return $this->timeout;
+    }
+
+    /**
+     * Returns the path to the custom log file, if any.
+     */
+    public function file(): ?string
+    {
+        return $this->file;
     }
 }

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -2,12 +2,12 @@
 
 namespace Laravel\Pail;
 
-use Throwable;
+use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Laravel\Pail\Printers\CliPrinter;
-use Illuminate\Support\Facades\Process;
 use Laravel\Pail\ValueObjects\MessageLogged;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class ProcessFactory
 {
@@ -55,7 +55,7 @@ class ProcessFactory
                                 }
                             }
                         })
-                        ->filter(fn ($messageLogged) => $messageLogged instanceof MessageLogged)
+                        ->filter(fn (MessageLogged|null $messageLogged): bool => $messageLogged instanceof MessageLogged)
                         ->filter(fn (MessageLogged $messageLogged) => $options->accepts($messageLogged))
                         ->each(fn (MessageLogged $messageLogged) => $printer->print($messageLogged));
                 }

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -2,9 +2,10 @@
 
 namespace Laravel\Pail;
 
-use Illuminate\Support\Facades\Process;
+use Throwable;
 use Illuminate\Support\Str;
 use Laravel\Pail\Printers\CliPrinter;
+use Illuminate\Support\Facades\Process;
 use Laravel\Pail\ValueObjects\MessageLogged;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -42,10 +43,10 @@ class ProcessFactory
                         ->map(function (string $line) use ($options, $output): ?MessageLogged {
                             try {
                                 return MessageLogged::fromJson($line);
-                            } catch (\Throwable) {
+                            } catch (Throwable) {
                                 try {
                                     return MessageLogged::fromLaravelLog($line);
-                                } catch (\Throwable) {
+                                } catch (Throwable) {
                                     if ($options->file() === null) {
                                         $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
                                     }
@@ -54,7 +55,7 @@ class ProcessFactory
                                 }
                             }
                         })
-                        ->filter()
+                        ->filter(fn ($messageLogged) => $messageLogged instanceof MessageLogged)
                         ->filter(fn (MessageLogged $messageLogged) => $options->accepts($messageLogged))
                         ->each(fn (MessageLogged $messageLogged) => $printer->print($messageLogged));
                 }

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -39,13 +39,19 @@ class ProcessFactory
 
                     $lines
                         ->filter(fn (string $line) => $line !== '')
-                        ->map(function (string $line) use ($output): ?MessageLogged {
+                        ->map(function (string $line) use ($options, $output): ?MessageLogged {
                             try {
                                 return MessageLogged::fromJson($line);
                             } catch (\Throwable) {
-                                $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
+                                try {
+                                    return MessageLogged::fromLaravelLog($line);
+                                } catch (\Throwable) {
+                                    if ($options->file() === null) {
+                                        $output->writeln('  <fg=yellow>⚠ Pail skipped a malformed log line.</>');
+                                    }
 
-                                return null;
+                                    return null;
+                                }
                             }
                         })
                         ->filter()

--- a/src/ValueObjects/MessageLogged.php
+++ b/src/ValueObjects/MessageLogged.php
@@ -23,6 +23,40 @@ class MessageLogged implements Stringable
     }
 
     /**
+     * Creates a new instance of the message logged from a standard Laravel log line.
+     *
+     * Handles lines in the format: [YYYY-MM-DD HH:MM:SS] channel.LEVEL: message
+     */
+    public static function fromLaravelLog(string $line): static
+    {
+        if (! preg_match('/^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\] \w+\.(\w+): (.+)$/s', $line, $matches)) {
+            throw new \InvalidArgumentException('Cannot parse log line.');
+        }
+
+        $time = Carbon::createFromFormat('Y-m-d H:i:s', $matches[1]);
+        assert($time instanceof Carbon);
+
+        $datetime = $time->format('Y-m-d\TH:i:s.uP');
+        $levelName = strtoupper($matches[2]);
+        $message = trim($matches[3]);
+
+        $context = [
+            '__pail' => [
+                'origin' => [
+                    'type' => 'http',
+                    'method' => '',
+                    'path' => '',
+                    'auth_id' => null,
+                    'auth_email' => null,
+                    'trace' => null,
+                ],
+            ],
+        ];
+
+        return new static($message, $datetime, $levelName, $context);
+    }
+
+    /**
      * Creates a new instance of the message logged from a json string.
      */
     public static function fromJson(string $json): static

--- a/src/ValueObjects/MessageLogged.php
+++ b/src/ValueObjects/MessageLogged.php
@@ -4,6 +4,7 @@ namespace Laravel\Pail\ValueObjects;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
+use InvalidArgumentException;
 use Stringable;
 
 class MessageLogged implements Stringable
@@ -30,7 +31,7 @@ class MessageLogged implements Stringable
     public static function fromLaravelLog(string $line): static
     {
         if (! preg_match('/^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\] \w+\.(\w+): (.+)$/s', $line, $matches)) {
-            throw new \InvalidArgumentException('Cannot parse log line.');
+            throw new InvalidArgumentException('Cannot parse log line.');
         }
 
         $time = Carbon::createFromFormat('Y-m-d H:i:s', $matches[1]);
@@ -43,7 +44,7 @@ class MessageLogged implements Stringable
         $context = [
             '__pail' => [
                 'origin' => [
-                    'type' => 'http',
+                    'type' => 'cli',
                     'method' => '',
                     'path' => '',
                     'auth_id' => null,

--- a/tests/Features/CustomFileTest.php
+++ b/tests/Features/CustomFileTest.php
@@ -1,0 +1,40 @@
+<?php
+
+test('renders entries from a custom log file', function () {
+    expect('[2024-01-01 03:04:05] local.INFO: Custom file message')->toPailFile(<<<'EOF'
+        ┌ 03:04:05 INFO ─────────────────────────────────┐
+        │ Custom file message                            │
+        └────────────────────────── : / • Auth ID: guest ┘
+
+        EOF,
+    );
+});
+
+test('renders multiple entries from a custom log file', function () {
+    expect([
+        '[2024-01-01 03:04:05] local.INFO: First message',
+        '[2024-01-01 03:04:05] local.ERROR: Second message',
+    ])->toPailFile(<<<'EOF'
+        ┌ 03:04:05 INFO ─────────────────────────────────┐
+        │ First message                                  │
+        └────────────────────────── : / • Auth ID: guest ┘
+        ┌ 03:04:05 ERROR ────────────────────────────────┐
+        │ Second message                                 │
+        └────────────────────────── : / • Auth ID: guest ┘
+
+        EOF,
+    );
+});
+
+test('does not warn on unparseable lines in custom file mode', function () {
+    expect([
+        '#0 /app/stack/trace/line.php(42): Some::method()',
+        '[2024-01-01 03:04:05] local.INFO: Valid entry after trace',
+    ])->toPailFile(<<<'EOF'
+        ┌ 03:04:05 INFO ─────────────────────────────────┐
+        │ Valid entry after trace                        │
+        └────────────────────────── : / • Auth ID: guest ┘
+
+        EOF,
+    );
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -44,7 +44,6 @@ uses(TestCase::class)
 
             $GLOBALS['customFileProcess'] = null;
         }
-        }
     })->in(__DIR__);
 
 /*
@@ -147,6 +146,7 @@ expect()->extend('toPailFile', function (string $expectedOutput) {
     $waitFor = trim($matches[1] ?? (string) $lastLine);
 
     $deadline = time() + 15;
+
     do {
         $output = preg_replace('/\e\[[\d;]*m/', '', $GLOBALS['customFileProcess']->getOutput());
         usleep(10);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -24,6 +24,7 @@ use function Orchestra\Testbench\remote;
 */
 
 $GLOBALS['process'] = null;
+$GLOBALS['customFileProcess'] = null;
 
 uses(TestCase::class)
     ->beforeAll(fn () => $_ENV['PAIL_TESTS'] = true)
@@ -37,6 +38,12 @@ uses(TestCase::class)
             $GLOBALS['process'] = null;
 
             File::deleteDirectory(storage_path('pail'));
+        }
+        if ($GLOBALS['customFileProcess']) {
+            (fn () => $this->process->stop())->call($GLOBALS['customFileProcess']);
+
+            $GLOBALS['customFileProcess'] = null;
+        }
         }
     })->in(__DIR__);
 
@@ -101,7 +108,7 @@ expect()->extend('toPail', function (string $expectedOutput, array $options = []
 });
 
 expect()->extend('toPailFile', function (string $expectedOutput) {
-    if ($GLOBALS['process'] === null) {
+    if ($GLOBALS['customFileProcess'] === null) {
         if (! is_dir(storage_path('pail'))) {
             mkdir(storage_path('pail'), 0755, true);
         }
@@ -109,7 +116,7 @@ expect()->extend('toPailFile', function (string $expectedOutput) {
         $tempFile = storage_path('pail/test.log');
         touch($tempFile);
 
-        $process = $GLOBALS['process'] = remote([
+        $process = $GLOBALS['customFileProcess'] = remote([
             'pail',
             "--file=\"{$tempFile}\"",
         ], env: [
@@ -139,10 +146,11 @@ expect()->extend('toPailFile', function (string $expectedOutput) {
     preg_match('/^\[.*?\] \w+\.\w+: (.+)$/', (string) $lastLine, $matches);
     $waitFor = trim($matches[1] ?? (string) $lastLine);
 
+    $deadline = time() + 15;
     do {
-        $output = preg_replace('/\e\[[\d;]*m/', '', $GLOBALS['process']->getOutput());
+        $output = preg_replace('/\e\[[\d;]*m/', '', $GLOBALS['customFileProcess']->getOutput());
         usleep(10);
-    } while (! str_contains($output, $waitFor));
+    } while (! str_contains($output, $waitFor) && time() < $deadline);
 
     $output = Str::of($output)
         ->explode("\n")

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -66,12 +66,15 @@ expect()->extend('toPail', function (string $expectedOutput, array $options = []
 
         $process->start();
 
-        $process->waitUntil(function ($type, $output): bool {
+        $process->waitUntil(function ($_type, $output): bool {
             return str_contains($output, 'Tailing application logs.');
         });
     }
 
-    collect(Arr::wrap($this->value))
+    /** @var mixed $value */
+    $value = $this->value;
+
+    collect(Arr::wrap($value))
         ->each(function (string $code) {
             remote(['eval', ProcessUtils::escapeArgument(base64_encode($code.';'))])->run();
         });
@@ -80,6 +83,66 @@ expect()->extend('toPail', function (string $expectedOutput, array $options = []
         $output = preg_replace('/\e\[[\d;]*m/', '', $GLOBALS['process']->getOutput());
         usleep(10);
     } while (! str_contains($output, 'artisan eval'));
+
+    $output = Str::of($output)
+        ->explode("\n")
+        ->map(fn (string $line) => rtrim($line))
+        ->implode("\n");
+
+    expect($output)->toBe(<<<EOF
+
+           INFO  Tailing application logs. Press Ctrl+C to exit
+                         Use -v|-vv to show more details
+        $expectedOutput
+        EOF,
+    );
+
+    return $this;
+});
+
+expect()->extend('toPailFile', function (string $expectedOutput) {
+    if ($GLOBALS['process'] === null) {
+        if (! is_dir(storage_path('pail'))) {
+            mkdir(storage_path('pail'), 0755, true);
+        }
+
+        $tempFile = storage_path('pail/test.log');
+        touch($tempFile);
+
+        $process = $GLOBALS['process'] = remote([
+            'pail',
+            "--file=\"{$tempFile}\"",
+        ], env: [
+            'APP_DEBUG' => '(true)',
+            'PAIL_TESTS' => '(true)',
+        ]);
+
+        $process->start();
+
+        $process->waitUntil(function ($_type, $output): bool {
+            return str_contains($output, 'Tailing application logs.');
+        });
+    }
+
+    $tempFile = storage_path('pail/test.log');
+
+    /** @var mixed $fileValue */
+    $fileValue = $this->value;
+
+    collect(Arr::wrap($fileValue))
+        ->each(function (string $logLine) use ($tempFile) {
+            $phpCode = 'file_put_contents('.var_export($tempFile, true).', '.var_export($logLine."\n", true).', FILE_APPEND);';
+            remote(['eval', ProcessUtils::escapeArgument(base64_encode($phpCode))])->run();
+        });
+
+    $lastLine = collect(Arr::wrap($fileValue))->last();
+    preg_match('/^\[.*?\] \w+\.\w+: (.+)$/', (string) $lastLine, $matches);
+    $waitFor = trim($matches[1] ?? (string) $lastLine);
+
+    do {
+        $output = preg_replace('/\e\[[\d;]*m/', '', $GLOBALS['process']->getOutput());
+        usleep(10);
+    } while (! str_contains($output, $waitFor));
 
     $output = Str::of($output)
         ->explode("\n")

--- a/tests/Unit/MessageLoggedFromLaravelLogTest.php
+++ b/tests/Unit/MessageLoggedFromLaravelLogTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Laravel\Pail\ValueObjects\MessageLogged;
+
+beforeEach(function () {
+    $_ENV['PAIL_TESTS'] = true;
+});
+
+afterEach(function () {
+    unset($_ENV['PAIL_TESTS']);
+});
+
+test('parses all standard log levels', function (string $level) {
+    $line = "[2024-01-01 03:04:05] local.{$level}: Test message";
+
+    $message = MessageLogged::fromLaravelLog($line);
+
+    expect($message->level())->toBe($level)
+        ->and($message->message())->toBe('Test message');
+})->with(['INFO', 'ERROR', 'DEBUG', 'WARNING', 'NOTICE', 'CRITICAL', 'ALERT', 'EMERGENCY']);
+
+test('parses message correctly', function () {
+    $message = MessageLogged::fromLaravelLog('[2024-01-01 03:04:05] local.INFO: Custom file message');
+
+    expect($message->message())->toBe('Custom file message');
+});
+
+test('preserves json context in message', function () {
+    $line = '[2024-01-01 03:04:05] local.INFO: SELECT * FROM users WHERE id = 1 {"time":1.25,"bindings":[]} []';
+
+    $message = MessageLogged::fromLaravelLog($line);
+
+    expect($message->message())->toBe('SELECT * FROM users WHERE id = 1 {"time":1.25,"bindings":[]} []');
+});
+
+test('parses different channels', function () {
+    $message = MessageLogged::fromLaravelLog('[2024-01-01 03:04:05] production.INFO: Production message');
+
+    expect($message->level())->toBe('INFO')
+        ->and($message->message())->toBe('Production message');
+});
+
+test('has no auth id', function () {
+    $message = MessageLogged::fromLaravelLog('[2024-01-01 03:04:05] local.INFO: Test message');
+
+    expect($message->authId())->toBeNull();
+});
+
+test('returns correct time', function () {
+    $message = MessageLogged::fromLaravelLog('[2024-01-01 03:04:05] local.INFO: Test message');
+
+    expect($message->time())->toBe('03:04:05');
+});
+
+test('returns correct date', function () {
+    $message = MessageLogged::fromLaravelLog('[2024-01-01 03:04:05] local.INFO: Test message');
+
+    expect($message->date())->toBe('2024-01-01 03:04:05');
+});
+
+test('throws on unparseable lines', function (string $line) {
+    MessageLogged::fromLaravelLog($line);
+})->with([
+    'plain text' => ['not a valid log line'],
+    'stack trace line' => ['#0 /app/Http/Controllers/HomeController.php(42): SomeClass->method()'],
+    'empty string' => [''],
+    'json only' => ['{"message":"test","level":"info"}'],
+])->throws(InvalidArgumentException::class);


### PR DESCRIPTION
## Description

This PR resolves #37 by adding support for tailing custom log files (e.g., `query.log`, `error.log`) directly via a new `--file` option in the `pail` command.

## Changes

### New `--file` option in `PailCommand`

The `pail` command now accepts a `--file` option that allows developers to specify a path to any custom log file to tail:

```bash
php artisan pail --file=/path/to/storage/logs/query.log
php artisan pail --file=storage/logs/query.log --level=info
```

When `--file` is provided:
- Pail tails the specified file directly using `tail -F`
- The file is **not** created or destroyed by Pail (it must already exist or be written to by your application)
- All existing filters (`--filter`, `--message`, `--level`, `--auth`) continue to work as expected

When `--file` is **not** provided, the existing behavior is preserved (a temporary `.pail` file is created and managed by Pail).

### Updated `Options` class

The `Options` class has been updated to:
- Accept an optional `$file` parameter in its constructor
- Parse the `--file` option from the command in `fromCommand()`
- Expose the value via a new `file()` method

## Motivation

Many Laravel applications use custom log channels and write to separate log files (e.g., `query.log` for DB queries, `slack.log`, `error.log`, etc.). Previously, developers had to use external tools like `tail -f` to monitor these files. This change allows Pail to tail any log file directly, providing a unified log monitoring experience.

## Example Usage

```php
// In your application (e.g., AppServiceProvider)
DB::listen(function ($query) {
    Log::channel('query')->info($query->sql, $query->bindings);
});
```

```bash
# Then tail the query log
php artisan pail --file=storage/logs/query.log
```

## Notes

- This implementation intentionally does **not** require changes to `laravel/framework`, as it works by directly tailing an existing file rather than intercepting the Laravel log channel system.
- The custom file is not wrapped in JSON format by default; Pail will attempt to parse lines and gracefully skip malformed ones (as it does with `.pail` files).

Closes #37