### PR TITLE
fix: avoid resolving the auth user when building log context

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -101,8 +101,8 @@ class Handler
                 'type' => 'http',
                 'method' => request()->method(),
                 'path' => request()->path(),
-                'auth_id' => Auth::id(),
-                'auth_email' => Auth::user() instanceof User ? Auth::user()->email : null, // @phpstan-ignore property.notFound
+                'auth_id' => Auth::hasUser() ? Auth::id() : null,
+                'auth_email' => Auth::hasUser() && Auth::user() instanceof User ? Auth::user()->email : null, // @phpstan-ignore property.notFound
             ],
         }]];
 


### PR DESCRIPTION
### Issue

When Pail's `MessageLogged` listener fires for an http-origin log line,
`Handler::context()` calls `Auth::id()` and `Auth::user()` unconditionally
to enrich the context. If the guard hasn't resolved a user yet, that
triggers the configured `UserProvider::retrieveById()`. If anything in
that resolution path logs (directly or transitively), the log call
re-enters Pail's listener -> `Auth::id()` -> `retrieveById()` -> log -> ...
until PHP runs out of stack.

This was reported previously in #39 and #40 with a custom `UserProvider`
that logs inside `retrieveById()`. It also reproduces with
[`directorytree/ldaprecord-laravel`](https://github.com/DirectoryTree/LdapRecord-Laravel),
which ships with `LDAP_LOGGING=true` by default, every bind/search fires
a `Log::info()` from the event listener that runs while the guard is
resolving the user. With Pail attached (`composer run dev`), the first
authenticated request loops.

### Fix

Guard the enrichment behind `Auth::hasUser()`, which reports whether a
user has already been resolved on the guard without triggering a resolve.
If no user is in memory when a log line fires, `auth_id` / `auth_email`
become `null`.

### Behavior change

- Auth middleware has already run: no change. `Auth::hasUser()` is
  true and `Auth::id()` returns the cached value.
- Log fires before the auth middleware: no observable change. The
  guard hadn't read the session cookie either, so `auth_id` was already
  `null`.
- Log fires from inside `retrieveById()`: now `auth_id: null` instead
  of recursing.